### PR TITLE
fix(auth): username should be sid

### DIFF
--- a/amlcenter/auth/pkiauth.py
+++ b/amlcenter/auth/pkiauth.py
@@ -118,7 +118,7 @@ def _get_sid_from_dn(dn):
     count = User.objects.filter(username=username).count()
     if count != 0:
         new_username = username[0:27]
-        count = User.objects.filter(username=new_username).count()  # __startswith
+        count = User.objects.filter(username__startswith=new_username).count()
         new_username = '{0!s}_{1!s}'.format(new_username, count + 1)
         username = new_username
 

--- a/amlcenter/auth/pkiauth.py
+++ b/amlcenter/auth/pkiauth.py
@@ -95,6 +95,36 @@ def _preprocess_dn(original_dn):
     return dn
 
 
+def _get_sid_from_dn(dn):
+    """
+    Formats username to return sid
+    """
+    if 'CN=' in dn:
+        cn = utils.find_between(dn, 'CN=', ',')
+    else:
+        cn = dn
+
+    # sanitize username
+    username = cn[0:30]
+    username = username.replace(' ', '_')  # no spaces
+    username = username.replace("'", "")  # no apostrophes
+    username = username.lower()  # all lowercase
+
+    username_last_underscore_index = username.rfind('_')
+    if username_last_underscore_index >= 0:
+        username = username[username_last_underscore_index + 1:]
+
+    # make sure this username doesn't exist
+    count = User.objects.filter(username=username).count()
+    if count != 0:
+        new_username = username[0:27]
+        count = User.objects.filter(username=new_username).count()  # __startswith
+        new_username = '{0!s}_{1!s}'.format(new_username, count + 1)
+        username = new_username
+
+    return username
+
+
 def _get_profile_by_dn(dn, issuer_dn='default issuer dn'):
     """
     Returns a user profile for a given DN
@@ -122,18 +152,7 @@ def _get_profile_by_dn(dn, issuer_dn='default issuer dn'):
 
         kwargs = {'display_name': cn, 'dn': dn, 'issuer_dn': issuer_dn}
         # sanitize username
-        username = cn[0:30]
-        username = username.replace(' ', '_')  # no spaces
-        username = username.replace("'", "")  # no apostrophes
-        username = username.lower()  # all lowercase
-        # make sure this username doesn't exist
-        count = User.objects.filter(username=username).count()
-        if count != 0:
-            new_username = username[0:27]
-            count = User.objects.filter(username__startswith=new_username).count()
-            new_username = '{0!s}_{1!s}'.format(new_username, count + 1)
-            username = new_username
-
+        username = _get_sid_from_dn(cn)
         # now check again - if this username exists, we have a problemce
         count = User.objects.filter(username=username).count()
         if count != 0:

--- a/amlcenter/scripts/fix_usernames.py
+++ b/amlcenter/scripts/fix_usernames.py
@@ -1,0 +1,29 @@
+"""
+Fix usernames
+
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.realpath(os.path.join(os.path.dirname(__file__), '../../')))
+
+from amlcenter import models
+from amlcenter.auth import pkiauth
+
+
+def run():
+    """
+    Create username for profile
+    """
+
+    for current_profile in models.Profile.objects.all():
+        print('------------')
+        current_profile_dn = current_profile.dn
+        current_profile_username = current_profile.user.username
+        print('Current DN: {}'.format(current_profile_dn))
+
+        new_username = pkiauth._get_sid_from_dn(current_profile_dn)
+        current_profile.user.username = new_username
+        current_profile.user.save()
+
+        print('Previous Username({}), New username({})'.format(current_profile_username, new_username))

--- a/tests/amlcenter/auth/test_pki_auth.py
+++ b/tests/amlcenter/auth/test_pki_auth.py
@@ -115,6 +115,21 @@ class PkiAuthenticationTest(TestCase):
 
         self.assertEquals(user_obj.username, 'user1')
 
+    def test_authenticate_full_with_cn_preprocess_dn_sid(self):
+        self.meta_dict['HTTP_X_SSL_AUTHENTICATED'] = 'SUCCESS'
+        self.meta_dict['HTTP_X_SSL_USER_DN'] = '/CN=Last First Mid Mid1 flast'
+        self.meta_dict['HTTP_X_SSL_ISSUER_DN'] = 'issuer'
+
+        results = self.pki_authentication.authenticate(self.request)
+
+        user_obj = results[0]
+        error_obj = results[1]
+
+        self.assertEquals(str(user_obj.__class__), "<class 'django.contrib.auth.models.User'>")
+        self.assertEquals(error_obj, None)
+
+        self.assertEquals(user_obj.username, 'flast')
+
     def test_authenticate_full_with_cn_preprocess_dn_already_exist(self):
         self.skipTest('TODO: Disable preprocess dn')
         # Mock user.objects.count()
@@ -169,7 +184,7 @@ class PkiAuthenticationTest(TestCase):
         # with name longer than 30 chars
         dn = 'This guy has a really really really long DN'
         profile = pkiauth._get_profile_by_dn(dn)
-        self.assertEqual(profile.user.username, 'this_guy_has_a_really_really_r')
+        self.assertEqual(profile.user.username, 'r')
 
     def test_duplicate_username(self):
         """
@@ -179,12 +194,16 @@ class PkiAuthenticationTest(TestCase):
         """
         # create a new user
         profile = pkiauth._get_profile_by_dn('Jones_jones')
-        self.assertEqual(profile.user.username, 'jones_jones')
+        self.assertEqual(profile.user.username, 'jones_2')
 
         # this dn has an "'" in it, but that gets stripped out before creating
         # the new user
         profile = pkiauth._get_profile_by_dn('jones jones\'')
-        self.assertEqual(profile.user.username, 'jones_jones_2')
+        self.assertEqual(profile.user.username, 'jones_3')
+
+        # Should get the first profile
+        profile = pkiauth._get_profile_by_dn('Jones_jones')
+        self.assertEqual(profile.user.username, 'jones_2')
 
     def test_case_username(self):
         # DN with mixed case should match


### PR DESCRIPTION
AMLNG-402

**Description**     
Sharing folders with another user should use the sid.
"we want to be able to share the folder by just entering the standard <username>"

**Acceptance Criteria**   
DN:`first_last_sid`, username should be `sid`
  
**How to test code**    
```
make test_parallel
```
To Run Script
```
python manage.py runscript fix_usernames
```

**Please Review**     
@aml-development/aml-backend-team    

**Checklist**
- [x] Read CONTRIBUTING.md
- [x] Write code to complete task 
- [x] Python Code is PEP8 Compliant
- [x] Add unit tests for new code
- [ ] All tests must pass before merging the pull request
- [ ] At least 2 people reviewed code

